### PR TITLE
Strip description of newlines to make setuptools happy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ pkgname = 'namespace'
 pkgname_qualified = 'fsc.' + pkgname
 
 with open('doc/description.txt', 'r') as f:
-    description = f.read()
+    description = f.read().strip()
 try:
     with open('doc/README', 'r') as f:
         readme = f.read()


### PR DESCRIPTION
Setuptools emits a warning (and temporarily broke) when the description contains a newline. For this reason, we strip the unnecessary final newline from the description.

Relevant links: https://github.com/pypa/setuptools/pull/2538, https://github.com/pypa/setuptools/issues/2539